### PR TITLE
Member and committee tabs

### DIFF
--- a/website/internal/admin.py
+++ b/website/internal/admin.py
@@ -16,9 +16,12 @@ class MemberAdmin(admin.ModelAdmin):
 class EventAdmin(admin.ModelAdmin):
     actions = ['delete_selected']
     ordering = ['name']
-    list_filter = ('created_by', 'point_person', 'confirmed', 'complete')
-    list_display = ('name','title', 'speaker_full_name', 'time', 'venue', 'point_person',
-                    'confirmed', 'complete')
+    # list_filter = ('created_by', 'point_person', 'confirmed', 'complete')
+    list_filter = ('created_by', 'point_person', 'confirmed')
+    # list_display = ('name','title', 'speaker_full_name', 'time', 'venue', 'point_person',
+    #                 'confirmed', 'complete')
+    list_display = ('name', 'title', 'speaker_full_name', 'time', 'venue', 'point_person',
+                    'confirmed')
     search_fields = ('name', 'title', 'speaker_first_name', 'speaker_last_name', 'point_person')
 
 class CommitteeAdmin(admin.ModelAdmin):

--- a/website/internal/models.py
+++ b/website/internal/models.py
@@ -11,18 +11,23 @@ class Member(AbstractUser):
         ('associate_second', 'Second Semester Associate'),
         ('alumni', 'Alumni'),
     )
-
+    # name = models.CharField(max_length=200, unique=False, null=True, default=None)
     semester_joined = models.CharField([semester_validator], max_length=6, blank=True)
     status = models.CharField(max_length=16, choices=STATUS_CHOICES)
     bio = models.TextField(blank=True)
     attendance = models.DecimalField(max_digits=5, decimal_places=2, default=0)
     title = models.TextField(default='General Member')
 
+
     # contact/social info
     cell_phone = models.CharField(max_length=11, blank=True)
     facebook = models.CharField(max_length=300, blank=True)
     instagram = models.CharField(max_length=300, blank=True)
     snapchat = models.CharField(max_length=300, blank=True)
+
+    @property
+    def isActive(self):
+        return self.status == ('active')
 
     def __unicode__(self):
         return u'%s' % self.username
@@ -41,7 +46,7 @@ class Event(models.Model):
     created_by = models.ForeignKey(Member, on_delete=models.CASCADE, related_name='created_events')
     point_person = models.ForeignKey(Member, on_delete=models.CASCADE, related_name='pp_events')
     confirmed = models.BooleanField(default=False)
-    complete = models.BooleanField(default=False)
+    # complete = models.BooleanField(default=False)
 
     # link fields
     facebook_link = models.CharField(max_length=300, blank=True)
@@ -71,6 +76,7 @@ class Committee(Group):
     vp = models.ForeignKey(Member, on_delete=models.CASCADE)
 
 class SubCommittee(Group):
+
     parent_committee = models.ForeignKey(Committee, on_delete=models.CASCADE,
                                   related_name='subcommittees')
     members = models.ManyToManyField(Member, related_name='subcommittees')

--- a/website/internal/static/internal/css/style.css
+++ b/website/internal/static/internal/css/style.css
@@ -188,6 +188,11 @@ p {
 	max-width: 60%;
 }
 
+.med-col {
+	width: 40%;
+	max-width: 40%;
+}
+
 .short-col {
 	width: 20%;
 	max-width: 20%;

--- a/website/internal/templates/internal/base.html
+++ b/website/internal/templates/internal/base.html
@@ -4,6 +4,7 @@
 
 {% url 'internal:event_list' as event_list_url %}
 {% url 'internal:member_list' as member_list_url %}
+{% url 'internal:committees' as committees_url %}
 
 <html>
     <head>
@@ -21,6 +22,7 @@
 			<h5 class='navbar-header'>THE BERKELEY FORUM</h5>
 			<a class="{% active request event_list_url %}" href="{{ event_list_url }}">Events</a>
 			<a class="{% active request member_list_url %}" href="{{ member_list_url }}">Directory</a>
+			<a class="{% active request committees_url %}" href="{{ committees_url }}">Committee</a>
 		</div>
 		<div id="container">
 			{% block pagecontent %}

--- a/website/internal/templates/internal/committee_members.html
+++ b/website/internal/templates/internal/committee_members.html
@@ -1,0 +1,19 @@
+{% extends 'internal/base.html' %}
+
+{% block title %}Committee members{% endblock %}
+
+{% block pagecontent %}
+	<div class="content">
+		<table class="list-table">
+            {% for member in members %}
+                {% if member.isActive %}
+						<tr class='row'>
+							<td class='half-row'>{{member.first_name}} {{member.last_name}}</td>
+							<td class='half-row'>{{ member.title}}</td>
+
+						</tr>
+					{% endif %}
+            {% endfor %}
+        </table>
+	</div>
+{% endblock %}

--- a/website/internal/templates/internal/committees.html
+++ b/website/internal/templates/internal/committees.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+{% extends 'internal/base.html' %}
+{% url 'internal:committees' as committees_url %}
+
+{% block title %}Committees{% endblock %}
+
+{% block pagecontent %}
+	<div class="content">
+		<table class="list-table">
+			<tr class="header-row">
+
+				<th class='long-col'>Committees</th>
+
+			</tr>
+			{% if committees %}
+				{% for committee in committees %}
+
+					<tr class='event-row' data-url='{{ committees_url }}{{ committee.name }}'>
+
+						<td class="row">{{committee.name}}</td>
+
+
+					</tr>
+
+				{% endfor %}
+			{% else %}
+				<p>No Members to Display</p>
+			{% endif %}
+		</table>
+	</div>
+{% endblock %}

--- a/website/internal/templates/internal/member_details.html
+++ b/website/internal/templates/internal/member_details.html
@@ -1,0 +1,12 @@
+{% extends 'internal/base.html' %}
+
+{% block title %}{{member.first_name}} {{member.last_name}}{% endblock %}
+
+{% block pagecontent %}
+ 	<div class='content'>
+ 		<div>
+            <h3> {{member.first_name}} {{member.last_name}}</h3>
+ 			<h3> {{ member.bio }}</h3>
+ 		</div>
+ 	</div>
+ {% endblock %}

--- a/website/internal/templates/internal/member_list.html
+++ b/website/internal/templates/internal/member_list.html
@@ -1,8 +1,31 @@
 <!DOCTYPE html>
 {% extends 'internal/base.html' %}
+{% url 'internal:member_list' as member_list_url %}
 
-{% block title %}Directory{% endblock %}
+{% block title %}Members{% endblock %}
 
 {% block pagecontent %}
+	<div class="content">
+		<table class="list-table">
+			<tr class="header-row">
 
+				<th class='med-col'>Name</th>
+				<th class='med-col'>Role</th>
+			</tr>
+			{% if member_list %}
+				{% for member in member_list %}
+					{% if member.isActive %}
+						<tr class='event-row' data-url='{{ member_list_url }}{{ member.username }}'>
+
+							<td class='half-row'>{{member.first_name}} {{member.last_name}}</td>
+							<td class='half-row'>{{ member.title}}</td>
+
+						</tr>
+					{% endif %}
+				{% endfor %}
+			{% else %}
+				<p>No Members to Display</p>
+			{% endif %}
+		</table>
+	</div>
 {% endblock %}

--- a/website/internal/urls.py
+++ b/website/internal/urls.py
@@ -11,4 +11,6 @@ urlpatterns = [
     url(r'^register/$', views.register, name='register'),
     url(r'^events/(?P<event_name>.+)/$', views.event_details, name='event_details'),
     url(r'^members/(?P<username>.+)/$', views.member_details, name='member_details'),
+    url(r'^committees/$', views.committees, name='committees'),
+    url(r'^committees/(?P<name>.+)/$', views.committee_members, name='committee_members')
 ]

--- a/website/internal/views.py
+++ b/website/internal/views.py
@@ -2,9 +2,11 @@ from django.shortcuts import render
 from django.http import HttpResponse
 
 from .models import Event
+from .models import Member
+from .models import Committee
 
 def event_list(request):
-    lst = Event.objects.filter(complete=False).order_by('name')
+    lst = Event.objects.all().order_by('name')
     context = {'event_list': lst}
     return render(request, 'internal/event_list.html', context)
 
@@ -17,8 +19,27 @@ def register(request):
     return HttpResponse("You're trying to register")
 
 def member_list(request):
-    context = {}
+    lst = Member.objects.all()
+    context = {'member_list': lst}
     return render(request, 'internal/member_list.html', context)
 
 def member_details(request, username):
-    return HttpResponse("You're looking at member %s" % username)
+    member = Member.objects.get(username=username)
+    context = {'member': member}
+    return render(request, 'internal/member_details.html', context)
+
+def committees(request):
+    lst = Committee.objects.all()
+    context = {'committees': lst}
+    return render(request, 'internal/committees.html', context)
+
+def committee_members(request, name):
+    comm = Committee.objects.get(name = name)
+    print(comm)
+    lst = Member.objects.filter(committees__in=[comm])
+    print(lst)
+    context = {'members': lst}
+    return render(request, 'internal/committee_members.html', context)
+
+
+


### PR DESCRIPTION
@ellenluo 

For these following changes: No DB changes were required, although I did manually change some tables to create test data. Also, my original design for the Committees page was to display all committees that the logged in user was on, and on clicking those committees, they would display all members. To achieve this change, we just need to filter committees we display on committees.html. However, this change is more difficult than seems, though, because a request defaults to an AnonymousUser when no "get_user" method is defined in the backend. See this link: 
https://stackoverflow.com/questions/5376985/django-request-user-is-always-anonymous-user
I wasn't too sure how to implement this change, so I just opted to display all Committees on committee.html, and trigger their members upon click. 


admin.py: For some reason I was running into errors with the Member field "confirmed". An error message told me that the "confirmed" field was not an option when I triggered its usages in views.py. I therefore commented out all usages of the field. 

models.py: Forgot to remove the field I added then commented out. I added an isActive method to allow templates to check if a member was active before displaying him/her. 

Base.html: Added a Committee tab

committees.html: Shows all committees and displays their members upon clicking

committee_members.html: Shows all members that are part of a particular committee

member_list.html: Analogous to event_list.html. Shows list of all members and displays Bio and Full name upon clicking a member. 

member_details.html: Analogous to event_details.html: Shows bio and name of each member. 

Adding corresponding views and urls. Most interesting is the committee_members view which filters Members by committee and displays relevant members within committee_members.html. 


